### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "python3 rss.py"

--- a/README.md
+++ b/README.md
@@ -47,4 +47,5 @@ Please note that all push notification services are optinal and can be empty or 
 } 
 ```
 
-
+### Test on Repl.it
+[![Run on Repl.it](https://repl.it/badge/github/maschhoff/RSSNotipy)](https://repl.it/github/maschhoff/RSSNotipy)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).